### PR TITLE
Fix throwing missing file error

### DIFF
--- a/src/AppleSafariPinGenerator.php
+++ b/src/AppleSafariPinGenerator.php
@@ -68,7 +68,7 @@ final class AppleSafariPinGenerator implements GeneratorInterface
             return $callback($tempSource, $tempTarget);
         } finally {
             \unlink($tempSource);
-            \unlink($tempTarget);
+            @\unlink($tempTarget);
         }
     }
 


### PR DESCRIPTION
Fix throwing error for non-existent file when the conversion didn't work, instead of the thrown error